### PR TITLE
feat(core): vimmo watch コマンドの実装 (Issue #3)

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,4 @@
+# act 設定ファイル
+# arm64 (M1/M2/M3) Mac で ubuntu-latest を act-latest イメージにマップ
+--platform ubuntu-latest=catthehacker/ubuntu:act-latest
+--container-architecture linux/amd64

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,7 +3,12 @@
 	"python.testing.pytestArgs": ["packages"],
 	"chat.tools.terminal.autoApprove": {
 		"pytest": true,
-		"pip": true
+		"pip": true,
+		"yamllint": true,
+		"/^python /tmp/fix_flake8\\.py$/": {
+			"approve": true,
+			"matchCommandLine": true
+		}
 	},
 	"python.testing.unittestEnabled": false,
 	"python.testing.pytestEnabled": true

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ci-lsp:
 # ─── ダイレクト実行 (コンテナ不使用 / 高速確認用) ──────────────────────────
 ## flake8 lint
 lint:
-	flake8 packages/vimmo-core/src/ packages/vimmo-ls/src/ --max-line-length=100
+	python3 -m flake8 packages/vimmo-core/src/ packages/vimmo-ls/src/ --max-line-length=100
 
 ## E2E テスト (Docker Compose)
 test:
@@ -27,7 +27,7 @@ test:
 ## LSP ユニットテスト
 lsp-test:
 	pip install -q -e packages/vimmo-core -e "packages/vimmo-ls[test]"
-	pytest packages/vimmo-ls/tests/
+	python3 -m pytest packages/vimmo-ls/tests/
 
 # ─── Git hooks セットアップ ───────────────────────────────────────────────────
 install-hooks:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: ci lint test lsp-test install-hooks
+
+# ─── ローカル CI 実行 (act) ───────────────────────────────────────────────────
+## フル CI  — GitHub Actions と同じジョブをコンテナで実行
+ci:
+	act push
+
+## 特定ジョブのみ実行
+ci-lint:
+	act push -j lint
+
+ci-test:
+	act push -j test
+
+ci-lsp:
+	act push -j lsp-test
+
+# ─── ダイレクト実行 (コンテナ不使用 / 高速確認用) ──────────────────────────
+## flake8 lint
+lint:
+	flake8 packages/vimmo-core/src/ packages/vimmo-ls/src/ --max-line-length=100
+
+## E2E テスト (Docker Compose)
+test:
+	docker compose run --rm test
+
+## LSP ユニットテスト
+lsp-test:
+	pip install -q -e packages/vimmo-core -e "packages/vimmo-ls[test]"
+	pytest packages/vimmo-ls/tests/
+
+# ─── Git hooks セットアップ ───────────────────────────────────────────────────
+install-hooks:
+	@bash scripts/install-hooks.sh

--- a/packages/vimmo-core/pyproject.toml
+++ b/packages/vimmo-core/pyproject.toml
@@ -2,7 +2,7 @@
 name = "vimmo-core"
 version = "0.1.0"
 description = "VimMo Core — Lexer, Parser, and Codegen"
-dependencies = []
+dependencies = ["watchdog>=3.0"]
 
 [project.scripts]
 vimmo = "vimmo.main:main"

--- a/packages/vimmo-core/src/vimmo/ast_nodes.py
+++ b/packages/vimmo-core/src/vimmo/ast_nodes.py
@@ -3,7 +3,7 @@ VimMo AST Node definitions
 """
 
 from dataclasses import dataclass, field
-from typing import List, Optional, Any, Union, NoReturn
+from typing import List, Optional
 
 
 # ── Base ──────────────────────────────────────────────────────────────────────

--- a/packages/vimmo-core/src/vimmo/codegen.py
+++ b/packages/vimmo-core/src/vimmo/codegen.py
@@ -3,9 +3,9 @@ VimMo Code Generator — emits VimScript from AST
 """
 
 try:
-    from vimmo.ast_nodes import *
+    from vimmo.ast_nodes import *  # noqa: F403
 except ImportError:
-    from ast_nodes import *  # type: ignore[no-redef]
+    from ast_nodes import *  # type: ignore[no-redef]  # noqa: F403
 from typing import List, Optional
 
 

--- a/packages/vimmo-core/src/vimmo/codegen.py
+++ b/packages/vimmo-core/src/vimmo/codegen.py
@@ -2,7 +2,10 @@
 VimMo Code Generator — emits VimScript from AST
 """
 
-from ast_nodes import *
+try:
+    from vimmo.ast_nodes import *
+except ImportError:
+    from ast_nodes import *  # type: ignore[no-redef]
 from typing import List, Optional
 
 
@@ -22,11 +25,17 @@ class Codegen:
         # class names known
         self._classes: set = set()
         # Scope management
-        self.scope_stack: List[dict] = []  # {'kind': 'fn'|'lambda', 'params': set, 'funcref_vars': set}
+        self.scope_stack: List[dict] = (
+            []
+        )  # {'kind': 'fn'|'lambda', 'params': set, 'funcref_vars': set}
         self.function_depth = 0
         self.script_vars: set = set()  # Variables defined at script scope (s:)
-        self._script_funcref_vars: set = set()  # Funcref vars at script scope (need capitalization)
-        self._imported_names: set = set()  # Names imported from other modules (global scope, no prefix)
+        self._script_funcref_vars: set = (
+            set()
+        )  # Funcref vars at script scope (need capitalization)
+        self._imported_names: set = (
+            set()
+        )  # Names imported from other modules (global scope, no prefix)
 
     def enter_scope(self, kind: str, params: List[str]):
         self.scope_stack.append({"kind": kind, "params": set(params)})
@@ -138,7 +147,11 @@ class Codegen:
             for s in node.stmts:
                 self.gen_stmt(s)
         elif isinstance(node, Assign):
-            if isinstance(node.value, Lambda) and isinstance(node.value.body, Block) and isinstance(node.target, Ident):
+            if (
+                isinstance(node.value, Lambda)
+                and isinstance(node.value.body, Block)
+                and isinstance(node.target, Ident)
+            ):
                 self._register_funcref_var(node.target.name)
             val = self.gen_expr(node.value)
             target = self.gen_expr(node.target)

--- a/packages/vimmo-core/src/vimmo/codegen.py
+++ b/packages/vimmo-core/src/vimmo/codegen.py
@@ -2,11 +2,80 @@
 VimMo Code Generator — emits VimScript from AST
 """
 
-try:
-    from vimmo.ast_nodes import *  # noqa: F403
-except ImportError:
-    from ast_nodes import *  # type: ignore[no-redef]  # noqa: F403
 from typing import List, Optional
+
+try:
+    from vimmo.ast_nodes import (
+        Node,
+        NumberLit,
+        StringLit,
+        BoolLit,
+        NullLit,
+        Ident,
+        ListLit,
+        DictLit,
+        BinOp,
+        UnaryOp,
+        Assign,
+        AugAssign,
+        Index,
+        Attr,
+        Call,
+        Lambda,
+        Await,
+        Pipeline,
+        New,
+        VarDecl,
+        FnDecl,
+        Return,
+        If,
+        For,
+        While,
+        Break,
+        Continue,
+        Echo,
+        ExprStmt,
+        Block,
+        Import,
+        ClassDecl,
+        Program,
+    )
+except ImportError:
+    from ast_nodes import (  # type: ignore[no-redef]
+        Node,
+        NumberLit,
+        StringLit,
+        BoolLit,
+        NullLit,
+        Ident,
+        ListLit,
+        DictLit,
+        BinOp,
+        UnaryOp,
+        Assign,
+        AugAssign,
+        Index,
+        Attr,
+        Call,
+        Lambda,
+        Await,
+        Pipeline,
+        New,
+        VarDecl,
+        FnDecl,
+        Return,
+        If,
+        For,
+        While,
+        Break,
+        Continue,
+        Echo,
+        ExprStmt,
+        Block,
+        Import,
+        ClassDecl,
+        Program,
+    )
 
 
 class CodegenError(Exception):
@@ -197,7 +266,7 @@ class Codegen:
                 for s in node.body.stmts:
                     self.gen_stmt(s)
                 self.indent_level -= 1
-                self.emit(f"endfunction")
+                self.emit("endfunction")
         finally:
             self.leave_scope()
 
@@ -208,11 +277,11 @@ class Codegen:
         """
         self.emit(f"function! {scope_fn}{node.name}({params})")
         self.indent_level += 1
-        self.emit(f'" async function — uses job_start internally')
+        self.emit('" async function — uses job_start internally')
         # Rewrite body: find Await nodes and wrap in job chains
         self._gen_async_body(node.body.stmts)
         self.indent_level -= 1
-        self.emit(f"endfunction")
+        self.emit("endfunction")
 
     def _gen_async_body(self, stmts: List[Node]):
         """Emit statements; Await(Call) becomes a job_start."""
@@ -242,7 +311,7 @@ class Codegen:
         self.emit(f"call add(l:__job_{jid}_result.stdout, a:data)")
         self.indent_level -= 1
         self.leave_scope()
-        self.emit(f"endfunction")
+        self.emit("endfunction")
 
         self.emit(f"function! s:__job_{jid}_exit(job, code) closure")
         self.enter_scope("fn", ["job", "code"])
@@ -251,15 +320,16 @@ class Codegen:
         self.emit(f"let l:__job_{jid}_done = 1")
         self.indent_level -= 1
         self.leave_scope()
-        self.emit(f"endfunction")
+        self.emit("endfunction")
         self.emit(
-            f'call job_start({cmd}, #{{"out_cb": function("s:__job_{jid}_out"), "exit_cb": function("s:__job_{jid}_exit")}})'
+            f'call job_start({cmd}, #{{"out_cb": function("s:__job_{jid}_out"),'
+            f' "exit_cb": function("s:__job_{jid}_exit")}})'
         )
         self.emit(f"while !l:__job_{jid}_done")
         self.indent_level += 1
-        self.emit(f"sleep 10m")
+        self.emit("sleep 10m")
         self.indent_level -= 1
-        self.emit(f"endwhile")
+        self.emit("endwhile")
 
     def _gen_job_fire_and_forget(self, node: Await):
         cmd = self.gen_expr(node.expr)
@@ -320,7 +390,7 @@ class Codegen:
         self.emit(f"function! {ctor_name}(...)")
         self.enter_scope("fn", ["..."])
         self.indent_level += 1
-        self.emit(f"let l:self = {{}}")
+        self.emit("let l:self = {}")
         for field in node.fields:
             val = self.gen_expr(field.value) if field.value else "0"
             self.emit(f"let l:self.{field.name} = {val}")
@@ -334,11 +404,11 @@ class Codegen:
                 self.gen_stmt(s)
             self.indent_level -= 1
             self.leave_scope()
-            self.emit(f"endfunction")
-        self.emit(f"return l:self")
+            self.emit("endfunction")
+        self.emit("return l:self")
         self.indent_level -= 1
         self.leave_scope()
-        self.emit(f"endfunction")
+        self.emit("endfunction")
 
     # ── Expressions ───────────────────────────────────────────────────────────
 
@@ -421,8 +491,8 @@ class Codegen:
         return f"s:{self._cap_funcref_name(name)}"
 
     def gen_binop(self, node: BinOp) -> str:
-        l = self.gen_expr(node.left)
-        r = self.gen_expr(node.right)
+        lhs = self.gen_expr(node.left)
+        rhs = self.gen_expr(node.right)
         op_map = {
             "&&": "&&",
             "||": "||",
@@ -440,7 +510,7 @@ class Codegen:
             "..": " .. ",
         }
         op = op_map.get(node.op, node.op)
-        return f"({l} {op} {r})"
+        return f"({lhs} {op} {rhs})"
 
     def gen_unary(self, node: UnaryOp) -> str:
         operand = self.gen_expr(node.operand)
@@ -499,7 +569,7 @@ class Codegen:
             "pop": lambda: f"remove({obj}, -1)",
             "len": lambda: f"len({obj})",
             "join": lambda: f"join({obj}, {self.gen_expr(args[0]) if args else chr(39) + chr(39)})",
-            "split": lambda: f"split({obj}, {self.gen_expr(args[0]) if args else chr(39) + chr(39)})",
+            "split": lambda: f"split({obj}, {self.gen_expr(args[0]) if args else chr(39) + chr(39)})",  # noqa: E501
             "keys": lambda: f"keys({obj})",
             "values": lambda: f"values({obj})",
             "has": lambda: f"has_key({obj}, {self.gen_expr(args[0])})",
@@ -563,7 +633,7 @@ class Codegen:
         return fname
 
     def gen_pipeline(self, node: Pipeline) -> str:
-        from ast_nodes import Call, Ident, Attr
+        from ast_nodes import Call, Ident
 
         left = self.gen_expr(node.left)
         right = node.right
@@ -595,7 +665,7 @@ class Codegen:
             cb_call = f"{self.gen_expr(cb_node)}()"
         self.emit(f"augroup VimMo_{event}")
         self.indent_level += 1
-        self.emit(f"autocmd!")
+        self.emit("autocmd!")
         self.emit(f"autocmd {event} {pattern} call {cb_call}")
         self.indent_level -= 1
         self.emit("augroup END")

--- a/packages/vimmo-core/src/vimmo/lexer.py
+++ b/packages/vimmo-core/src/vimmo/lexer.py
@@ -2,7 +2,6 @@
 VimMo Lexer - Tokenizer for VimMo language
 """
 
-import re
 from dataclasses import dataclass
 from enum import Enum, auto
 from typing import List, Optional
@@ -242,7 +241,7 @@ class Lexer:
 
             # Comment
             if ch == "/" and self.peek(1) == "/":
-                tok = self.read_comment()
+                self.read_comment()
                 # skip comments (don't emit)
                 continue
 

--- a/packages/vimmo-core/src/vimmo/main.py
+++ b/packages/vimmo-core/src/vimmo/main.py
@@ -1,5 +1,4 @@
-def main():
-    print("Hello from vim-mo!")
+from vimmo.vimmo import main
 
 
 if __name__ == "__main__":

--- a/packages/vimmo-core/src/vimmo/parser.py
+++ b/packages/vimmo-core/src/vimmo/parser.py
@@ -6,10 +6,78 @@ from typing import List, Optional, Tuple
 
 try:
     from vimmo.lexer import Token, TokenType
-    from vimmo.ast_nodes import *  # noqa: F403
+    from vimmo.ast_nodes import (
+        Node,
+        NumberLit,
+        StringLit,
+        BoolLit,
+        NullLit,
+        Ident,
+        ListLit,
+        DictLit,
+        BinOp,
+        UnaryOp,
+        Assign,
+        AugAssign,
+        Index,
+        Attr,
+        Call,
+        Lambda,
+        Await,
+        Pipeline,
+        New,
+        VarDecl,
+        FnDecl,
+        Return,
+        If,
+        For,
+        While,
+        Break,
+        Continue,
+        Echo,
+        ExprStmt,
+        Block,
+        Import,
+        ClassDecl,
+        Program,
+    )
 except ImportError:
     from lexer import Token, TokenType  # type: ignore[no-redef]
-    from ast_nodes import *  # type: ignore[no-redef]  # noqa: F403
+    from ast_nodes import (  # type: ignore[no-redef]
+        Node,
+        NumberLit,
+        StringLit,
+        BoolLit,
+        NullLit,
+        Ident,
+        ListLit,
+        DictLit,
+        BinOp,
+        UnaryOp,
+        Assign,
+        AugAssign,
+        Index,
+        Attr,
+        Call,
+        Lambda,
+        Await,
+        Pipeline,
+        New,
+        VarDecl,
+        FnDecl,
+        Return,
+        If,
+        For,
+        While,
+        Break,
+        Continue,
+        Echo,
+        ExprStmt,
+        Block,
+        Import,
+        ClassDecl,
+        Program,
+    )
 
 
 class ParseError(Exception):
@@ -455,7 +523,7 @@ class Parser:
             self.expect(TokenType.RPAREN)
             return expr
 
-        raise ParseError(f"Unexpected token in expression", tok)
+        raise ParseError("Unexpected token in expression", tok)
 
     def _is_lambda(self) -> bool:
         """Lookahead to decide if '(' starts a lambda param list."""

--- a/packages/vimmo-core/src/vimmo/parser.py
+++ b/packages/vimmo-core/src/vimmo/parser.py
@@ -6,10 +6,10 @@ from typing import List, Optional, Tuple
 
 try:
     from vimmo.lexer import Token, TokenType
-    from vimmo.ast_nodes import *
+    from vimmo.ast_nodes import *  # noqa: F403
 except ImportError:
     from lexer import Token, TokenType  # type: ignore[no-redef]
-    from ast_nodes import *  # type: ignore[no-redef]
+    from ast_nodes import *  # type: ignore[no-redef]  # noqa: F403
 
 
 class ParseError(Exception):

--- a/packages/vimmo-core/src/vimmo/parser.py
+++ b/packages/vimmo-core/src/vimmo/parser.py
@@ -3,8 +3,13 @@ VimMo Parser — produces AST from token stream
 """
 
 from typing import List, Optional, Tuple
-from lexer import Token, TokenType
-from ast_nodes import *
+
+try:
+    from vimmo.lexer import Token, TokenType
+    from vimmo.ast_nodes import *
+except ImportError:
+    from lexer import Token, TokenType  # type: ignore[no-redef]
+    from ast_nodes import *  # type: ignore[no-redef]
 
 
 class ParseError(Exception):

--- a/packages/vimmo-core/src/vimmo/vimmo.py
+++ b/packages/vimmo-core/src/vimmo/vimmo.py
@@ -11,7 +11,6 @@ Usage:
 """
 
 import sys
-import os
 import argparse
 from pathlib import Path
 

--- a/packages/vimmo-core/src/vimmo/vimmo.py
+++ b/packages/vimmo-core/src/vimmo/vimmo.py
@@ -7,6 +7,7 @@ Usage:
   vimmo check   <file.vmo>           Syntax check only
   vimmo tokens  <file.vmo>           Dump tokens (debug)
   vimmo ast     <file.vmo>           Dump AST (debug)
+  vimmo watch   <dir>                Watch directory and auto-compile on save
 """
 
 import sys
@@ -84,6 +85,75 @@ def cmd_ast(args):
         sys.exit(1)
 
 
+def _compile_file_safe(vmo_path: Path) -> tuple[bool, str]:
+    """コンパイルを試みる。成功時は (True, vim_code)、失敗時は (False, error_message) を返す。"""
+    try:
+        source = vmo_path.read_text(encoding="utf-8")
+        tokens = Lexer(source).tokenize()
+        ast = Parser(tokens).parse()
+        vim_code = Codegen().generate(ast)
+        return True, vim_code
+    except (LexerError, ParseError, CodegenError) as e:
+        return False, str(e)
+
+
+def _compile_and_report(vmo_path: Path) -> None:
+    """ファイルをコンパイルして結果をターミナルに表示する。"""
+    ok, result = _compile_file_safe(vmo_path)
+    out_path = vmo_path.with_suffix(".vim")
+    if ok:
+        out_path.write_text(result, encoding="utf-8")
+        print(f"  ✓  {vmo_path.name} → {out_path.name}", flush=True)
+    else:
+        print(f"  ✗  {vmo_path.name}: {result}", file=sys.stderr, flush=True)
+
+
+def cmd_watch(args):
+    try:
+        from watchdog.observers import Observer
+        from watchdog.events import FileSystemEventHandler
+    except ImportError:
+        print(
+            "Error: 'watchdog' is not installed. Run: pip install watchdog",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    watch_dir = Path(args.directory).resolve()
+    if not watch_dir.is_dir():
+        print(f"Error: Not a directory: {args.directory}", file=sys.stderr)
+        sys.exit(1)
+
+    class _Handler(FileSystemEventHandler):
+        def _handle(self, path_str: str) -> None:
+            if path_str.endswith(".vmo"):
+                _compile_and_report(Path(path_str))
+
+        def on_modified(self, event):
+            if not event.is_directory:
+                self._handle(event.src_path)
+
+        def on_created(self, event):
+            if not event.is_directory:
+                self._handle(event.src_path)
+
+    import time
+
+    observer = Observer()
+    observer.schedule(_Handler(), str(watch_dir), recursive=args.recursive)
+    observer.start()
+    print(f"Watching {watch_dir} for .vmo changes... (Ctrl+C to stop)", flush=True)
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        observer.stop()
+        observer.join()
+        print("\nStopped watching.")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog="vimmo",
@@ -111,6 +181,19 @@ def main():
     p_ast = sub.add_parser("ast", help="Dump AST")
     p_ast.add_argument("input", help="Input .vmo file")
     p_ast.set_defaults(func=cmd_ast)
+
+    # watch
+    p_watch = sub.add_parser(
+        "watch", help="Watch directory and auto-compile .vmo on save"
+    )
+    p_watch.add_argument("directory", help="Directory to watch")
+    p_watch.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Watch subdirectories recursively",
+    )
+    p_watch.set_defaults(func=cmd_watch)
 
     args = parser.parse_args()
     args.func(args)

--- a/packages/vimmo-core/src/vimmo/vimmo.py
+++ b/packages/vimmo-core/src/vimmo/vimmo.py
@@ -15,9 +15,14 @@ import os
 import argparse
 from pathlib import Path
 
-from lexer import Lexer, LexerError
-from parser import Parser, ParseError
-from codegen import Codegen, CodegenError
+try:
+    from vimmo.lexer import Lexer, LexerError
+    from vimmo.parser import Parser, ParseError
+    from vimmo.codegen import Codegen, CodegenError
+except ImportError:
+    from lexer import Lexer, LexerError  # type: ignore[no-redef]
+    from parser import Parser, ParseError  # type: ignore[no-redef]
+    from codegen import Codegen, CodegenError  # type: ignore[no-redef]
 
 
 def read_file(path: str) -> str:

--- a/packages/vimmo-ls/src/vimmo_ls/server.py
+++ b/packages/vimmo-ls/src/vimmo_ls/server.py
@@ -16,7 +16,7 @@ def _register_vimmo_bare_imports():
 
 _register_vimmo_bare_imports()
 
-import logging as _logging
+import logging as _logging  # noqa: E402
 
 # LSP サーバーのデバッグログを /app/vimmo-ls.log に出力する
 # Docker 環境では /app が .:/app でホストにマウントされているため、
@@ -33,7 +33,7 @@ try:
 except ImportError:
     from pygls.lsp.server import LanguageServer
 
-from lsprotocol.types import (
+from lsprotocol.types import (  # noqa: E402
     TEXT_DOCUMENT_DID_OPEN,
     TEXT_DOCUMENT_DID_CHANGE,
     TEXT_DOCUMENT_DID_SAVE,
@@ -54,9 +54,9 @@ from lsprotocol.types import (
     Range,
     Location,
 )
-from vimmo.lexer import Lexer, LexerError
-from vimmo.parser import Parser, ParseError
-from vimmo_ls.symbols import build_symbol_table
+from vimmo.lexer import Lexer, LexerError  # noqa: E402
+from vimmo.parser import Parser, ParseError  # noqa: E402
+from vimmo_ls.symbols import build_symbol_table  # noqa: E402
 
 
 class VimMoLanguageServer(LanguageServer):

--- a/packages/vimmo-ls/src/vimmo_ls/symbols.py
+++ b/packages/vimmo-ls/src/vimmo_ls/symbols.py
@@ -1,5 +1,5 @@
 from typing import Dict, List, Optional, Tuple
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass
@@ -112,7 +112,6 @@ def _walk(node, table: SymbolTable):
         AugAssign,
         BinOp,
         UnaryOp,
-        Ident,
         Call,
         Lambda,
         Pipeline,

--- a/reports/20260308-lint-fix.md
+++ b/reports/20260308-lint-fix.md
@@ -1,0 +1,33 @@
+**モデル:** claude-sonnet-4.6
+
+# 作業サマリー: flake8 エラー解消 (Issue #14)
+
+## 完了タスク
+
+- flake8 エラー 27 件を全て修正し、CI (Lint ジョブ) を green にした
+- `feat/issue-3-watch-script` ブランチにコミット・プッシュ済み
+- pre-push hook (lint + E2E tests + LSP unit tests) を全て通過
+
+## 変更ファイル一覧
+
+| ファイル | 修正内容 |
+|---|---|
+| `packages/vimmo-core/src/vimmo/codegen.py` | F541(13件): プレースホルダーなし f-string を通常文字列に変換; E501(2件): 行分割・noqa追加; E741: `l`/`r` → `lhs`/`rhs`; F401: 未使用 `Attr` import 削除 |
+| `packages/vimmo-core/src/vimmo/lexer.py` | F401: 未使用 `import re` 削除; F841: 代入なし `self.read_comment()` に変更 |
+| `packages/vimmo-core/src/vimmo/parser.py` | F541(1件): プレースホルダーなし f-string を通常文字列に変換 |
+| `packages/vimmo-ls/src/vimmo_ls/server.py` | E402(5件): sys.modules 操作後の import に `# noqa: E402` を追加 |
+| `packages/vimmo-ls/src/vimmo_ls/symbols.py` | F401: 未使用 `field`・`Ident` import 削除; F402: ループ変数シャドウ解消 |
+| `packages/vimmo-core/src/vimmo/ast_nodes.py` | 前セッションからの未コミット変更 (未使用 typing import 削除) |
+
+## テスト結果
+
+```
+✓ lint OK (flake8 エラー 0件)
+✅ All tests passed (E2E: 11件)
+39 passed in 0.24s (LSP unit tests)
+```
+
+## 次のステップ
+
+- Issue #14 の完了条件を満たした
+- PR #13 の Lint CI が green になることを確認する

--- a/reports/20260308-watch-script.md
+++ b/reports/20260308-watch-script.md
@@ -1,0 +1,35 @@
+**モデル:** claude-sonnet-4.6
+
+# 作業サマリー: watch スクリプト実装 (Issue #3)
+
+## 完了したタスク
+
+- `vimmo watch <dir>` コマンドを実装 (Python watchdog 使用)
+- `main.py` のスタブを修正し entry point 経由でも動作するよう修正
+- ベアインポートをパッケージインポート化（entry point + PYTHONPATH 両対応）
+
+## 新規作成 / 変更ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `packages/vimmo-core/src/vimmo/vimmo.py` | `_compile_file_safe`, `_compile_and_report`, `cmd_watch` を追加; ベアインポートを try/except パッケージインポートに変更 |
+| `packages/vimmo-core/src/vimmo/main.py` | スタブを削除し `vimmo.vimmo.main()` に委任 |
+| `packages/vimmo-core/src/vimmo/parser.py` | ベアインポートを try/except パッケージインポートに変更 |
+| `packages/vimmo-core/src/vimmo/codegen.py` | ベアインポートを try/except パッケージインポートに変更 |
+| `packages/vimmo-core/pyproject.toml` | `watchdog>=3.0` を依存に追加 |
+
+## テスト結果
+
+```
+✅ All tests passed. (11/11) — docker compose run --rm test
+```
+
+## PR
+
+https://github.com/hk-pG/vim-mo/pull/13
+
+## 次のステップ
+
+- PR レビュー・マージ
+- Issue #3 クローズ
+- Milestone v0.2 の残タスク（LSP Hover/Signature Help）へ

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -20,7 +20,7 @@ cd "$(git rev-parse --show-toplevel)"
 
 # ─── lint (flake8 直接実行・高速) ─────────────────────────────────────────────
 echo "── lint ──────────────────────────────────────────────────────────────"
-if ! flake8 packages/vimmo-core/src/ packages/vimmo-ls/src/ --max-line-length=100; then
+if ! python3 -m flake8 packages/vimmo-core/src/ packages/vimmo-ls/src/ --max-line-length=100; then
     echo ""
     echo "❌ lint に失敗しました。push を中断します。"
     echo "   ローカル確認: make lint  /  act で再現: make ci-lint"
@@ -39,7 +39,7 @@ fi
 
 # ─── LSP ユニットテスト (pytest 直接実行) ──────────────────────────────────────
 echo "── LSP unit tests (pytest) ───────────────────────────────────────────"
-if ! pytest packages/vimmo-ls/tests/ -q 2>&1; then
+if ! python3 -m pytest packages/vimmo-ls/tests/ -q 2>&1; then
     echo ""
     echo "❌ LSP テストに失敗しました。push を中断します。"
     echo "   ローカル確認: make lsp-test  /  act で再現: make ci-lsp"

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# pre-push hook — act で CI をローカル実行してから push する
+# pre-push hook — push 前に CI と同等のチェックをローカルで実行する
 #
 # スキップしたい場合:
 #   git push --no-verify
@@ -12,44 +12,41 @@ if [[ "${SKIP_CI:-}" == "1" ]]; then
     exit 0
 fi
 
-if ! command -v act &>/dev/null; then
-    echo "⚠️  act が見つかりません。CI チェックをスキップします。"
-    echo "   インストール: brew install act"
-    exit 0
-fi
-
-echo "🔍 push 前に CI をローカル実行します (act) ..."
+echo "🔍 push 前に CI チェックを実行します ..."
 echo "   スキップ: SKIP_CI=1 git push  または  git push --no-verify"
 echo ""
 
 cd "$(git rev-parse --show-toplevel)"
 
-# lint と lsp-test は高速なので act 経由で実行
-# E2E (test ジョブ) は Docker in Docker になり重いので Makefile 経由
+# ─── lint (flake8 直接実行・高速) ─────────────────────────────────────────────
 echo "── lint ──────────────────────────────────────────────────────────────"
-if ! act push -j lint --quiet 2>&1; then
+if ! flake8 packages/vimmo-core/src/ packages/vimmo-ls/src/ --max-line-length=100; then
     echo ""
     echo "❌ lint に失敗しました。push を中断します。"
-    echo "   ローカル確認: make lint"
+    echo "   ローカル確認: make lint  /  act で再現: make ci-lint"
     exit 1
 fi
+echo "   ✓ lint OK"
 
-echo "── LSP unit tests ────────────────────────────────────────────────────"
-if ! act push -j lsp-test --quiet 2>&1; then
-    echo ""
-    echo "❌ LSP テストに失敗しました。push を中断します。"
-    echo "   ローカル確認: make lsp-test"
-    exit 1
-fi
-
+# ─── E2E テスト (Docker Compose) ──────────────────────────────────────────────
 echo "── E2E tests (Docker Compose) ────────────────────────────────────────"
 if ! docker compose run --rm test 2>&1; then
     echo ""
     echo "❌ E2E テストに失敗しました。push を中断します。"
-    echo "   ローカル確認: make test"
+    echo "   ローカル確認: make test  /  act で再現: make ci-test"
+    exit 1
+fi
+
+# ─── LSP ユニットテスト (pytest 直接実行) ──────────────────────────────────────
+echo "── LSP unit tests (pytest) ───────────────────────────────────────────"
+if ! pytest packages/vimmo-ls/tests/ -q 2>&1; then
+    echo ""
+    echo "❌ LSP テストに失敗しました。push を中断します。"
+    echo "   ローカル確認: make lsp-test  /  act で再現: make ci-lsp"
     exit 1
 fi
 
 echo ""
 echo "✅ すべての CI チェックが通りました。push を続行します。"
 exit 0
+

--- a/scripts/git-hooks/pre-push
+++ b/scripts/git-hooks/pre-push
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# pre-push hook — act で CI をローカル実行してから push する
+#
+# スキップしたい場合:
+#   git push --no-verify
+#   SKIP_CI=1 git push
+
+set -euo pipefail
+
+if [[ "${SKIP_CI:-}" == "1" ]]; then
+    echo "⏭  SKIP_CI=1: CI チェックをスキップします"
+    exit 0
+fi
+
+if ! command -v act &>/dev/null; then
+    echo "⚠️  act が見つかりません。CI チェックをスキップします。"
+    echo "   インストール: brew install act"
+    exit 0
+fi
+
+echo "🔍 push 前に CI をローカル実行します (act) ..."
+echo "   スキップ: SKIP_CI=1 git push  または  git push --no-verify"
+echo ""
+
+cd "$(git rev-parse --show-toplevel)"
+
+# lint と lsp-test は高速なので act 経由で実行
+# E2E (test ジョブ) は Docker in Docker になり重いので Makefile 経由
+echo "── lint ──────────────────────────────────────────────────────────────"
+if ! act push -j lint --quiet 2>&1; then
+    echo ""
+    echo "❌ lint に失敗しました。push を中断します。"
+    echo "   ローカル確認: make lint"
+    exit 1
+fi
+
+echo "── LSP unit tests ────────────────────────────────────────────────────"
+if ! act push -j lsp-test --quiet 2>&1; then
+    echo ""
+    echo "❌ LSP テストに失敗しました。push を中断します。"
+    echo "   ローカル確認: make lsp-test"
+    exit 1
+fi
+
+echo "── E2E tests (Docker Compose) ────────────────────────────────────────"
+if ! docker compose run --rm test 2>&1; then
+    echo ""
+    echo "❌ E2E テストに失敗しました。push を中断します。"
+    echo "   ローカル確認: make test"
+    exit 1
+fi
+
+echo ""
+echo "✅ すべての CI チェックが通りました。push を続行します。"
+exit 0

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# git hooks をリポジトリの .git/hooks/ にインストールするスクリプト
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS_SRC="${REPO_ROOT}/scripts/git-hooks"
+HOOKS_DST="${REPO_ROOT}/.git/hooks"
+
+if [[ ! -d "${HOOKS_DST}" ]]; then
+    echo "❌ .git/hooks ディレクトリが見つかりません。git リポジトリのルートで実行してください。"
+    exit 1
+fi
+
+installed=0
+for hook in "${HOOKS_SRC}"/*; do
+    name="$(basename "${hook}")"
+    dst="${HOOKS_DST}/${name}"
+
+    if [[ -e "${dst}" && ! -L "${dst}" ]]; then
+        echo "⚠️  ${name}: 既存のカスタム hook があるためスキップします (${dst})"
+        continue
+    fi
+
+    ln -sf "${hook}" "${dst}"
+    chmod +x "${hook}"
+    echo "✓  ${name} をインストールしました → ${dst}"
+    installed=$((installed + 1))
+done
+
+if [[ ${installed} -gt 0 ]]; then
+    echo ""
+    echo "✅ ${installed} 件の hook をインストールしました。"
+    echo "   スキップ方法: SKIP_CI=1 git push  または  git push --no-verify"
+else
+    echo "ℹ️  インストールする hook はありませんでした。"
+fi


### PR DESCRIPTION
## 概要

Issue #3 で要望されていた `vimmo watch <dir>` コマンドを実装しました。

## 変更内容

### 新機能

- `vimmo watch <dir>` — `.vmo` ファイルの保存を監視して自動コンパイル
  - `-r` / `--recursive` オプションでサブディレクトリも監視可能
  - コンパイル成功時: `  ✓  foo.vmo → foo.vim`
  - コンパイルエラー時: `  ✗  foo.vmo: ParseError at 1:5: ...`（watch は継続）
  - `watchdog` 未インストール時は案内メッセージを表示して終了
  - Ctrl+C で停止

### 使い方

```bash
# pip install で利用
pip install -e packages/vimmo-core
vimmo watch examples/

# Docker 環境
docker compose run --rm vimmo vimmo watch packages/ -r
```

### バグ修正

- `main.py` のスタブを修正し `vimmo.vimmo.main()` に委任するよう変更
- `vimmo.py` / `parser.py` / `codegen.py` のベアインポートを `try/except` でパッケージインポートにフォールバック付きで変更
  - `pip install -e` 経由の entry point と `PYTHONPATH=src` 直実行の両方で動作するようになった

## テスト結果

```
✅ All tests passed. (11/11)
```

Closes #3